### PR TITLE
Adjust regex used to require resources

### DIFF
--- a/lib/truepill.rb
+++ b/lib/truepill.rb
@@ -6,7 +6,7 @@ require "truepill/response"
 require "truepill/version"
 
 resources_path = File.expand_path('truepill/resources/*.rb', File.dirname(__FILE__))
-Dir[resources_path].each { |f| require f[/\/lib\/(.+)\.rb$/, 1] }
+Dir[resources_path].each { |f| require f[/\/lib\/(truepill\/resources\/.+)\.rb$/, 1] }
 
 require 'active_support/core_ext/hash'
 


### PR DESCRIPTION
If the files to be included have another ancestor named `lib`, the current
regex will capture the wrong path to be included.

For example, path [1] will try to be included as:
`ruby/gems/2.6.0/gems/truepill-0.0.8/lib/truepill/resources/prescription`

instead of:
`truepill/resources/prescription`

[1] /Users/example/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/truepill-0.0.8/lib/truepill/resources/prescription.rb